### PR TITLE
FixWindowDrawing.js の変更案

### DIFF
--- a/js/plugins/FixWindowDrawing.js
+++ b/js/plugins/FixWindowDrawing.js
@@ -22,12 +22,13 @@
     'use strict';
     Bitmap.prototype.checkDirty = function() {
         if (this._dirty) {
-            var baseTexture = this._baseTexture;
-            setTimeout(function() {
-                baseTexture.update();
-            }, 0);
-            this._dirty = false;
+            setTimeout(this.clearDirty.bind(this), 0);
         }
+    };
+
+    Bitmap.prototype.clearDirty = function() {
+        this._baseTexture.update();
+        this._dirty = false;
     };
     
     var _Window_Message_terminateMessage =

--- a/js/plugins/FixWindowDrawing.js
+++ b/js/plugins/FixWindowDrawing.js
@@ -23,11 +23,17 @@
     Bitmap.prototype.checkDirty = function() {
         if (this._dirty) {
             var baseTexture = this._baseTexture;
-            baseTexture.update();
             setTimeout(function() {
                 baseTexture.update();
             }, 0);
             this._dirty = false;
         }
+    };
+    
+    var _Window_Message_terminateMessage =
+        Window_Message.prototype.terminateMessage;
+    Window_Message.prototype.terminateMessage = function() {
+        _Window_Message_terminateMessage.call(this);
+        this.contents.clear();
     };
 })();


### PR DESCRIPTION
お疲れ様です。
以下の変更案です。

・baseTexture.update() を繰り返さないようにすること
・ダーティフラグクリア処理のメソッド化

以上、ご検討お願いいたします。

なお、ほかの多くのWindow系クラスは
contents.clear() を refresh() メソッドで行っているようです。
本来なら Window_Base クラスに refresh() を追加して
その中で contents.clear() を行うのが適切であるように思います。
しかし本件はそこまで踏み込むものでもないと思うので
refresh() メソッドは作っていません。

あとは元々の Window_Message クラスも
newPage() メソッド内で contents.clear() しているのですが
表示に反映されないのが不可解ですね…。